### PR TITLE
Specific filepaths

### DIFF
--- a/TRELLIX/ACCESS_PROTECTION/ATP28_Targets_Microsoft_Outlook_With_'NotDoor'_Malware_File.md
+++ b/TRELLIX/ACCESS_PROTECTION/ATP28_Targets_Microsoft_Outlook_With_'NotDoor'_Malware_File.md
@@ -13,8 +13,8 @@ File
 ```tcl
 Rule {
 				Process {
-						Exclude OBJECT_NAME { -v "**\\Program Files\\Microsoft Office\\root\\Office*\\OUTLOOK.EXE" }
-						Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\Microsoft Office\\root\\Office*\\OUTLOOK.EXE" }
+						Exclude OBJECT_NAME { -v "%programfiles%\\Microsoft Office\\root\\Office*\\OUTLOOK.EXE" }
+						Exclude OBJECT_NAME { -v "%programfiles(x86)%\\Microsoft Office\\root\\Office*\\OUTLOOK.EXE" }
 				}
 				Target {
 					Match FILE {

--- a/TRELLIX/ACCESS_PROTECTION/ATP28_Targets_Microsoft_Outlook_With_'NotDoor'_Malware_Registry.md
+++ b/TRELLIX/ACCESS_PROTECTION/ATP28_Targets_Microsoft_Outlook_With_'NotDoor'_Malware_Registry.md
@@ -13,8 +13,8 @@ Registry
 ```tcl
 Rule {
 				Process {
-						Exclude OBJECT_NAME { -v "**\\Program Files\\Microsoft Office\\root\\Office*\\OUTLOOK.EXE" }
-						Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\Microsoft Office\\root\\Office*\\OUTLOOK.EXE" }
+						Exclude OBJECT_NAME { -v "%programfiles%\\Microsoft Office\\root\\Office*\\OUTLOOK.EXE" }
+						Exclude OBJECT_NAME { -v "%programfiles(x86)%\\Microsoft Office\\root\\Office*\\OUTLOOK.EXE" }
 				}
 				Target {
 					Match VALUE {

--- a/TRELLIX/ACCESS_PROTECTION/Detect_Abnormal_Content_Creation_(CVE-2021-26858).md
+++ b/TRELLIX/ACCESS_PROTECTION/Detect_Abnormal_Content_Creation_(CVE-2021-26858).md
@@ -24,7 +24,7 @@ Rule {
 				-v "*cleanup.bin"
 			}	
 			Exclude OBJECT_NAME -type PATH {
-				-v "**\\Program Files\\Microsoft\\Exchange Server\\**"
+				-v "%programfiles%\\Microsoft\\Exchange Server\\**"
 			}
 			Include -access "CREATE"
 		}

--- a/TRELLIX/ACCESS_PROTECTION/Detect_suspicious_operations_of_ServiceDll_registry_entry..md
+++ b/TRELLIX/ACCESS_PROTECTION/Detect_suspicious_operations_of_ServiceDll_registry_entry..md
@@ -13,8 +13,8 @@
  ```tcl
 Rule {
 	Process {
-			Exclude OBJECT_NAME {-v "**\\Windows\\System32\\svchost.exe"}
-			Exclude OBJECT_NAME {-v "**\\Windows\\system32\\services.exe"}
+			Exclude OBJECT_NAME {-v "%windir%\\System32\\svchost.exe"}
+			Exclude OBJECT_NAME {-v "%windir%\\system32\\services.exe"}
 		}
 
     Target {

--- a/TRELLIX/ACCESS_PROTECTION/Pupy_Rat_Hiding_Under_WerFault’s_Cover.md
+++ b/TRELLIX/ACCESS_PROTECTION/Pupy_Rat_Hiding_Under_WerFault’s_Cover.md
@@ -20,7 +20,7 @@ Rule {
 	Target {
 		Match FILE {
 			Include OBJECT_NAME { -v "faultrep.dll" }
-                        Exclude OBJECT_NAME { -v "**\\windows\\system32\\faultrep.dll" }
+                        Exclude OBJECT_NAME { -v "%windir%\\system32\\faultrep.dll" }
                         Include -access "CREATE READ"
 
 		}

--- a/TRELLIX/ACCESS_PROTECTION/T1003_Export_SAM_from_registry_or_LSA_Export_Registry_entry.md
+++ b/TRELLIX/ACCESS_PROTECTION/T1003_Export_SAM_from_registry_or_LSA_Export_Registry_entry.md
@@ -29,10 +29,10 @@ Rule {
             Exclude OBJECT_NAME { -v "SCHTASKS.EXE" }
             Exclude OBJECT_NAME { -v "REGEDIT.EXE" }
             Exclude OBJECT_NAME { -v "UpdateNotificationMgr.exe" }
-            Exclude OBJECT_NAME { -v "**\\Program Files\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
-            Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
-            Exclude OBJECT_NAME { -v "**\\program files\\microsoft office\\**.exe" }
-            Exclude OBJECT_NAME { -v "**\\program files (x86)\\microsoft office\\**.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles%\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles(x86)%\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles%\\microsoft office\\**.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles(x86)%\\microsoft office\\**.exe" }
             }
       }
       Target {

--- a/TRELLIX/ACCESS_PROTECTION/T1053_Scheduled_Task_for_FIN7_using_schtask_create_modify_delete.md
+++ b/TRELLIX/ACCESS_PROTECTION/T1053_Scheduled_Task_for_FIN7_using_schtask_create_modify_delete.md
@@ -16,12 +16,12 @@ Rule {
         Include AggregateMatch -xtype "inc1" {
             Include OBJECT_NAME { -v "**" }
             Exclude OBJECT_NAME { -v "WSQMCONS.exe" }
-            Exclude OBJECT_NAME { -v "**\\Program Files\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
-            Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
-            Exclude OBJECT_NAME { -v "**\\program files\\microsoft office\\**.exe" }
-            Exclude OBJECT_NAME { -v "**\\program files (x86)\\microsoft office\\**.exe" }
-            Exclude OBJECT_NAME { -v "**\\Program Files\\McAfee\\**" }
-            Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\McAfee\\**" }
+            Exclude OBJECT_NAME { -v "%programfiles%\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles(x86)%\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles%\\microsoft office\\**.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles(x86)%\\microsoft office\\**.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles%\\McAfee\\**" }
+            Exclude OBJECT_NAME { -v "%programfiles(x86)%\\McAfee\\**" }
          }
         Include AggregateMatch -xtype "inc2" {
        

--- a/TRELLIX/ACCESS_PROTECTION/T1555.003-Credentials_from_Web_Browsers_Chrome_Firefox_Opera_Credentials.md
+++ b/TRELLIX/ACCESS_PROTECTION/T1555.003-Credentials_from_Web_Browsers_Chrome_Firefox_Opera_Credentials.md
@@ -17,10 +17,10 @@ Rule {
             Include OBJECT_NAME { -v "**" }
             Exclude OBJECT_NAME {
                 -v "**\\Google\\Chrome\\Application\\chrome.exe"
-                -v "**\\Mozilla Firefox\\firefox.exe"
-                -v "**\\Windows\\System32\\browserexport.exe"
+                -v "%programfiles%\\Mozilla Firefox\\firefox.exe"
+                -v "%windir%\\System32\\browserexport.exe"
                 -v "**\\chrome-win\\chrome.exe"
-                -v "**\\Microsoft\\Edge\\Application\\msedge.exe"
+                -v "%programfiles(x86)%\\Microsoft\\Edge\\Application\\msedge.exe"
                 -v "**\\Opera\\*\\opera.exe"
                 -v "**\\Vivaldi\\Application\\vivaldi.exe"
                 -v "**\\Chromium\\Application\\chrome.exe"

--- a/TRELLIX/ACCESS_PROTECTION/T1570_Lateral_tool_transfer-Host_to_Remote.md
+++ b/TRELLIX/ACCESS_PROTECTION/T1570_Lateral_tool_transfer-Host_to_Remote.md
@@ -14,8 +14,8 @@ Files
 Rule {
       Process {
          Include OBJECT_NAME {-v "**"}
-         Exclude OBJECT_NAME { -v "**\\DLP\\Agent\\FCAGTE.EXE" }
-         Exclude OBJECT_NAME { -v "**\\DLP\\Agent\\fcag.exe" }
+         Exclude OBJECT_NAME { -v "%programfiles%\\McAfee\\DLP\\Agent\\FCAGTE.EXE" }
+         Exclude OBJECT_NAME { -v "%programfiles%\\McAfee\\DLP\\Agent\\fcag.exe" }
      }
 Target {
  Match FILE {

--- a/TRELLIX/DEFENSE_EVASION/MandiantMSV_detection_DLLSideLoadActivity.md
+++ b/TRELLIX/DEFENSE_EVASION/MandiantMSV_detection_DLLSideLoadActivity.md
@@ -18,7 +18,7 @@ Rule {
 	Target {
 		Match FILE {
 			Include OBJECT_NAME { -v "fxsst.dll" }
-			Exclude OBJECT_NAME { -v "**\\Windows\\System32\\fxsst.dll" }
+			Exclude OBJECT_NAME { -v "%windir%\\System32\\fxsst.dll" }
 			Include -access "EXECUTE"
 		}
 	}

--- a/TRELLIX/MALWARE_BEHAVIOR/Detect_Havoc_beacon_loaded_into_memory.md
+++ b/TRELLIX/MALWARE_BEHAVIOR/Detect_Havoc_beacon_loaded_into_memory.md
@@ -20,9 +20,9 @@ Rule {
     Target {
         Match FILE {
             Include OBJECT_NAME { -v "**.bin" }
-            Exclude OBJECT_NAME { -v "**\\Windows\\**" }
-            Exclude OBJECT_NAME { -v "**\\Program Files\\**" }
-            Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\**" }
+            Exclude OBJECT_NAME { -v "%windir%\\**" }
+            Exclude OBJECT_NAME { -v "%programfiles%\\**" }
+            Exclude OBJECT_NAME { -v "%programfiles(x86)%\\**" }
             Include -access "READ"
         }
     }

--- a/TRELLIX/MALWARE_BEHAVIOR/Detect_Ryuk_Ransomware_Behavior_By_Triggering_Memory_Scan.md
+++ b/TRELLIX/MALWARE_BEHAVIOR/Detect_Ryuk_Ransomware_Behavior_By_Triggering_Memory_Scan.md
@@ -16,10 +16,10 @@ Reaction SCAN ACTOR_PROCESS ScanAction REPORT_CLEAN_DELETE_PROCESS
 
                 Process {
                                 Include OBJECT_NAME { -v "**.exe"  }
-								Exclude OBJECT_NAME { -v "**\\Program Files\\**" }
-								Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\**" }
-								Exclude OBJECT_NAME { -v "**\\ProgramData\\**" }
-								Exclude OBJECT_NAME { -v "**\\Windows\\**" }
+								Exclude OBJECT_NAME { -v "%programfiles%\\**" }
+								Exclude OBJECT_NAME { -v "%programfiles(x86)%\\**" }
+								Exclude OBJECT_NAME { -v "%programdata%\\**" }
+								Exclude OBJECT_NAME { -v "%windir%\\**" }
 								Exclude VTP_PRIVILEGES -type BITMASK { -v 0x8 }
 								Include OBJECT_NAME { -v "**\\Windows\\Temp\\*.exe" }
  

--- a/TRELLIX/MALWARE_BEHAVIOR/Detection_on_havoc_payload_injected_into_memory_using_Local_PE_inject_tool.md
+++ b/TRELLIX/MALWARE_BEHAVIOR/Detection_on_havoc_payload_injected_into_memory_using_Local_PE_inject_tool.md
@@ -14,10 +14,10 @@ Rule {
                 Reaction SCAN TARGET_PROCESS ScanAction REPORT_CLEAN_DELETE_PROCESS
                 Target {
                         Match PROCESS {
-                                Exclude OBJECT_NAME { -v "**\\Windows\\**" }
-                                Exclude OBJECT_NAME { -v "**\\ProgramData\\**" }
-                                Exclude OBJECT_NAME { -v "**\\Program Files\\**" }
-                                Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\**" }                                                  
+                                Exclude OBJECT_NAME { -v "%windir%\\**" }
+                                Exclude OBJECT_NAME { -v "%programdata%\\**" }
+                                Exclude OBJECT_NAME { -v "%programfiles%\\**" }
+                                Exclude OBJECT_NAME { -v "%programfiles(x86)%\\**" }                                                  
                                 Include OBJECT_NAME { -v "**.exe" }
                                 Include PROCESS_CMD_LINE { -v "**-pe**" }
                                 Include -access "CREATE"

--- a/TRELLIX/MITRE/2024/T1083_scheduled_task.md
+++ b/TRELLIX/MITRE/2024/T1083_scheduled_task.md
@@ -16,13 +16,13 @@ Rule {
         Include AggregateMatch -xtype "inc1" {
             Include OBJECT_NAME { -v "**" }
             Exclude OBJECT_NAME { -v "WSQMCONS.exe" }
-            Exclude OBJECT_NAME { -v "**\\Program Files\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
-            Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
-            Exclude OBJECT_NAME { -v "**\\program files\\microsoft office\\**.exe" }
-            Exclude OBJECT_NAME { -v "**\\program files (x86)\\microsoft office\\**.exe" }
-            Exclude OBJECT_NAME { -v "**\\Program Files\\McAfee\\**" }
-            Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\McAfee\\**" }
-            Exclude OBJECT_NAME { -v "**\\Program Files (x86)\\FireEye\\xagt\\xagt.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles%\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles(x86)%\\Common Files\\microsoft shared\\ClickToRun\\*.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles%\\microsoft office\\**.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles(x86)%\\microsoft office\\**.exe" }
+            Exclude OBJECT_NAME { -v "%programfiles%\\McAfee\\**" }
+            Exclude OBJECT_NAME { -v "%programfiles(x86)%\\McAfee\\**" }
+            Exclude OBJECT_NAME { -v "%programfiles(x86)%\\FireEye\\xagt\\xagt.exe" }
          }
         Include AggregateMatch -xtype "inc2" {
        


### PR DESCRIPTION
Use specific filepaths for 'excludes' to prevent excluding unintended folder/file paths. There are many rules that do this correctly by referencing environment variables.